### PR TITLE
feat(card): 카드 디자인 선택 페이지 UI 구현 및 헤더 정렬 문제 개선

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,7 @@ import IngredientDetailList from "./pages/refrigerator/IngredientDetailList";
 import RefrigeratorMain from "./pages/refrigerator/RefrigeratorMain";
 import CardIssuePage from "./pages/card/CardIssuePage"; // 카드 발급 안내 페이지
 import CardDetailPage from "./pages/card/CardDetailPage"; // 카드 상세 페이지
-// import CardApplyPage from "./pages/card/CardApplyPage"; // 카드 신청 페이지
-// import TemplatePage from "./pages/template/TemplatePage"; // 템플릿 페이지
+import CardDesignSelectionPage from "./pages/card/CardDesignSelectionPage"; // 카드 상세 페이지
 
 function App() {
   return (
@@ -27,10 +26,9 @@ function App() {
         <Route path="/refrigeratormain" element={<RefrigeratorMain />} />
 
         {/* 카드 신청 관련 라우트 */}
-        {/* <Route path="/template" element={<TemplatePage />} /> */}
         <Route path="/card" element={<CardIssuePage />} />
         <Route path="/card/detail" element={<CardDetailPage />} />
-        {/* <Route path="/card/apply" element={<CardApplyPage />} /> */}
+        <Route path="/card/design" element={<CardDesignSelectionPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/card/CardDetail.css
+++ b/src/components/card/CardDetail.css
@@ -177,8 +177,8 @@ p {
 }
 
 .dropdown-header span {
-  font-size: 15px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 800;
   color: #333;
 }
 

--- a/src/components/card/CardDetail.css
+++ b/src/components/card/CardDetail.css
@@ -39,28 +39,6 @@
   position: relative;
 }
 
-.card-chip {
-  width: 32px;
-  height: 24px;
-  background-color: #dbdbdb;
-  border-radius: 3px;
-  margin-bottom: 40px;
-}
-
-.card-number {
-  font-size: 16px;
-  color: #333;
-  margin-bottom: 16px;
-  letter-spacing: 1px;
-}
-
-.card-owner {
-  display: flex;
-  justify-content: space-between;
-  font-size: 12px;
-  color: #333;
-}
-
 /* 카드 제목 및 설명 섹션 */
 .card-title-section {
   width: 100%;
@@ -72,13 +50,6 @@
   font-weight: 700;
   margin: 0;
   color: #000;
-}
-
-.card-title-section h3 {
-  font-size: 16px;
-  font-weight: 400;
-  margin: 4px 0 12px 0;
-  color: #333;
 }
 
 .divider {

--- a/src/components/common/header/Header.css
+++ b/src/components/common/header/Header.css
@@ -2,6 +2,7 @@
   display: flex;
   width: 100%;
   top: 0;
+  align-items: baseline;
 }
 
 .header {
@@ -19,15 +20,17 @@
   cursor: pointer;
   width: 24px;
   height: 24px;
+  flex-shrink: 0;
+  z-index: 1;
 }
 
 .header-title {
   font-size: 18px;
-  line-height: 24px;
   letter-spacing: -0.015em;
-  text-align: center;
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
 }

--- a/src/pages/card/CardDesignSelectionPage.css
+++ b/src/pages/card/CardDesignSelectionPage.css
@@ -1,0 +1,266 @@
+/* 전체 컨테이너 */
+.card-design-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background-color: #ffffff;
+  font-family: "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+  position: relative;
+}
+
+/* 컨텐츠 영역 */
+.card-design-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 100px; /* 메뉴 공간 확보 */
+}
+
+/* 타이틀 영역 */
+.card-design-title {
+  padding: 24px 20px;
+  text-align: center;
+}
+
+.card-design-title h2 {
+  font-size: 22px;
+  font-weight: bold;
+  margin: 0;
+  color: #333;
+}
+
+/* 카드 프리뷰 영역 */
+.card-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 20px;
+  margin-bottom: 40px;
+}
+
+/* 카드 이미지 스타일 */
+.card-image {
+  width: 190px;
+  height: 300px;
+  border-radius: 16px;
+  position: relative;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  margin-bottom: 20px;
+  transition: transform 0.3s;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+/* 카드 뒤집기 애니메이션 */
+.card-image.flipping {
+  transform: rotateY(180deg);
+}
+
+/* 기본 카드 앞면 */
+.card-image.frontBasic {
+  background: linear-gradient(to bottom, #ffcccc, #ffffff);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+}
+
+/* 기본 카드 뒷면 */
+.card-image.backBasic {
+  background: linear-gradient(to bottom, #f0f0f0, #dddddd);
+  transform: rotateY(180deg);
+}
+
+/* 커스텀 카드 */
+.card-image.frontCustom {
+  background: linear-gradient(to bottom, #c4e0ff, #ffffff);
+  position: relative;
+}
+
+/* 카드 뒷면 내용 */
+.card-back-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  transform: rotateY(180deg);
+}
+
+.signature-area {
+  width: 90%;
+  height: 40px;
+  background-color: #fff;
+  border-radius: 4px;
+  margin: 20px auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 14px;
+}
+
+.card-back-info {
+  margin-top: auto;
+  text-align: center;
+  font-size: 12px;
+  color: #555;
+}
+
+.card-back-info p {
+  margin: 4px 0;
+}
+
+.card-chip {
+  width: 40px;
+  height: 30px;
+  background-color: #cccccc;
+  border-radius: 5px;
+  position: absolute;
+  top: 40%;
+  right: 20px;
+}
+
+.card-number {
+  position: absolute;
+  top: 55%;
+  width: 100%;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 2px;
+  color: #333;
+  left: 0;
+}
+
+.card-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #333333;
+  color: white;
+  padding: 15px 20px;
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
+}
+
+.card-holder {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.card-expiry {
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+/* 화살표 버튼 스타일 */
+.card-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 28px;
+  font-weight: bold;
+  color: #333;
+  background-color: #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s;
+  z-index: 10;
+}
+
+.card-next-arrow {
+  right: -20px;
+}
+
+.card-prev-arrow {
+  left: -20px;
+}
+
+.card-arrow:hover {
+  transform: translateY(-50%) scale(1.05);
+}
+
+/* 디자인 선택 영역 */
+.design-selection {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+  text-align: center;
+  position: relative;
+}
+
+.design-label {
+  font-size: 16px;
+  font-weight: 500;
+  margin-bottom: 15px;
+  color: #333;
+  margin-top: 5px;
+}
+
+.design-button {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  padding: 10px 30px;
+  font-size: 14px;
+  cursor: pointer;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.design-button:hover {
+  background-color: #f8f8f8;
+}
+
+.custom-design-button {
+  background-color: #8470ff;
+  color: #ffffff;
+  border: none;
+}
+
+.custom-design-button:hover {
+  background-color: #7360ee;
+}
+
+/* 다음 버튼 */
+.next-button {
+  background-color: #6c5ce7;
+  color: white;
+  border: none;
+  border-radius: 25px;
+  padding: 12px 50px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  width: 80%;
+  margin: 0 auto;
+  margin-top: auto;
+  margin-bottom: 150px;
+}
+
+.next-button:hover {
+  background-color: #5b4bc4;
+}
+
+/* 반응형 스타일 */
+@media (max-width: 360px) {
+  .card-image {
+    width: 280px;
+    height: 180px;
+  }
+
+  .card-design-title h2 {
+    font-size: 20px;
+  }
+}

--- a/src/pages/card/CardDesignSelectionPage.js
+++ b/src/pages/card/CardDesignSelectionPage.js
@@ -1,0 +1,175 @@
+import React, { useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import "./CardDesignSelectionPage.css";
+
+// 필요한 아이콘 import
+import backArrow from "../../assets/backArrow.svg";
+import close from "../../assets/close.svg";
+
+// 헤더 및 푸터 관련 컴포넌트
+import Header from "../../components/common/header/Header";
+import Menu from "../../components/common/menu/Menu";
+
+// 카드 디자인 타입 상수
+const CARD_VIEWS = {
+  FRONT_BASIC: "frontBasic",
+  BACK_BASIC: "backBasic",
+  FRONT_CUSTOM: "frontCustom",
+};
+
+const CardDesignSelectionPage = () => {
+  const navigate = useNavigate();
+  const cardRef = useRef(null);
+
+  // 상태 관리
+  const [cardView, setCardView] = useState(CARD_VIEWS.FRONT_BASIC);
+  const [isFlipping, setIsFlipping] = useState(false);
+
+  // 네비게이션 핸들러
+  const handleBack = () => navigate(-1);
+  const handleClose = () => navigate("/card");
+  const handleNext = () => navigate("/card/verification");
+  const handleGoToCustomize = () => navigate("/card/customize");
+
+  // 카드 화면 전환 핸들러
+  const handleSwitchDesign = () => {
+    if (cardView === CARD_VIEWS.FRONT_BASIC) {
+      setCardView(CARD_VIEWS.FRONT_CUSTOM);
+    } else if (cardView === CARD_VIEWS.FRONT_CUSTOM) {
+      setCardView(CARD_VIEWS.FRONT_BASIC);
+    }
+  };
+
+  // 카드 뒤집기 핸들러
+  const handleFlipCard = () => {
+    if (isFlipping) return; // 이미 뒤집는 중이면 무시
+
+    setIsFlipping(true);
+
+    // 카드 뒤집기 애니메이션 적용
+    if (cardRef.current) {
+      cardRef.current.classList.add("flipping");
+    }
+
+    // 애니메이션 중간에 카드 면 변경
+    setTimeout(() => {
+      setCardView((prevView) =>
+        prevView === CARD_VIEWS.FRONT_BASIC
+          ? CARD_VIEWS.BACK_BASIC
+          : CARD_VIEWS.FRONT_BASIC
+      );
+    }, 150); // 애니메이션 중간 지점
+
+    // 애니메이션 완료 후 상태 초기화
+    setTimeout(() => {
+      if (cardRef.current) {
+        cardRef.current.classList.remove("flipping");
+      }
+      setIsFlipping(false);
+    }, 300); // 애니메이션 완료 시점
+  };
+
+  // 카드 디자인 라벨 텍스트 결정
+  const getDesignLabelText = () => {
+    switch (cardView) {
+      case CARD_VIEWS.FRONT_BASIC:
+        return "기본 디자인";
+      case CARD_VIEWS.BACK_BASIC:
+        return "기본 디자인 (뒷면)";
+      case CARD_VIEWS.FRONT_CUSTOM:
+        return "나만의 카드 직접 꾸며 보세요";
+      default:
+        return "";
+    }
+  };
+
+  // 디자인 선택 버튼 렌더링
+  const renderDesignButton = () => {
+    if (cardView === CARD_VIEWS.FRONT_BASIC) {
+      return (
+        <button className="design-button" onClick={handleFlipCard}>
+          뒷면 보기
+        </button>
+      );
+    } else if (cardView === CARD_VIEWS.BACK_BASIC) {
+      return (
+        <button className="design-button" onClick={handleFlipCard}>
+          앞면 보기
+        </button>
+      );
+    } else if (cardView === CARD_VIEWS.FRONT_CUSTOM) {
+      return (
+        <button
+          className="design-button custom-design-button"
+          onClick={handleGoToCustomize}
+        >
+          꾸미러 가기 ✨
+        </button>
+      );
+    }
+  };
+
+  return (
+    <div className="card-design-container">
+      <Header
+        leftIcon={backArrow}
+        title="카드 신청"
+        rightIcon={close}
+        onLeftClick={handleBack}
+        onRightClick={handleClose}
+      />
+
+      <div className="card-design-content">
+        {/* 안내 텍스트 */}
+        <div className="card-design-title">
+          <h2>카드 디자인을 선택해 주세요</h2>
+        </div>
+
+        {/* 카드 디자인 표시 영역 */}
+        <div className="card-preview">
+          {/* 카드 이미지 */}
+          <div ref={cardRef} className={`card-image ${cardView}`}>
+            {/* 화살표 버튼 렌더링 */}
+            {cardView === CARD_VIEWS.FRONT_BASIC && (
+              <div
+                className="card-arrow card-next-arrow"
+                onClick={handleSwitchDesign}
+              >
+                &#62;
+              </div>
+            )}
+
+            {cardView === CARD_VIEWS.FRONT_CUSTOM && (
+              <div
+                className="card-arrow card-prev-arrow"
+                onClick={handleSwitchDesign}
+              >
+                &#60;
+              </div>
+            )}
+
+            {/* 카드 뒷면 내용 */}
+            {cardView === CARD_VIEWS.BACK_BASIC && (
+              <div className="card-back-content"></div>
+            )}
+          </div>
+
+          {/* 디자인 선택 영역 */}
+          <div className="design-selection">
+            <p className="design-label">{getDesignLabelText()}</p>
+            {renderDesignButton()}
+          </div>
+        </div>
+      </div>
+
+      {/* 다음 버튼 */}
+      <button className="next-button" onClick={handleNext}>
+        선택
+      </button>
+
+      <Menu />
+    </div>
+  );
+};
+
+export default CardDesignSelectionPage;

--- a/src/pages/card/CardIssuePage.css
+++ b/src/pages/card/CardIssuePage.css
@@ -23,6 +23,7 @@
   flex-direction: column;
   justify-content: space-between;
   padding: 15px;
+  cursor: pointer;
 }
 
 /* 메시지 컨테이너 스타일 */

--- a/src/pages/card/CardIssuePage.js
+++ b/src/pages/card/CardIssuePage.js
@@ -16,8 +16,12 @@ const CardIssuePage = () => {
 
   const navigate = useNavigate();
 
+  const handleCardDetail = () => {
+    navigate("/card/detail");
+  };
+
   const handleCardIssue = () => {
-    navigate("/card/apply");
+    navigate("/card/design");
   };
 
   return (
@@ -30,7 +34,7 @@ const CardIssuePage = () => {
         onLeftClick={navigateToShop}
         onRightClick={navigateToNoti}
       />
-      <div className="card-wrapper"></div>
+      <div className="card-wrapper" onClick={handleCardDetail}></div>
 
       <div className="message-container">
         <h2 className="message-title">


### PR DESCRIPTION
## #️⃣연관된 이슈
#13 

## 📝작업 내용
1. 카드 발급받기 이벤트 헨들러 추가
 - 카드 이미지 클릭 시 **[카드 상세 페이지]** 로 이동
 - `카드 발급받기` 버튼 클릭 시 **[카드 디자인 페이지]** 로 이동
2. 카드 디자인 선택 기본 페이지 UI 구현
 - 기본 디자인의 경우 `앞면 보기` / `뒷면 보기` 버튼 클릭을 통한 뒤집기 효과, 오른쪽 화살표 클릭 시 커스텀 디자인으로 변경
 - 커스텀 디자인의 경우 오른쪽 화살표 클릭 시 기본 디자인으로 변경

#### 스크린샷
![카드 디자인 선택](https://github.com/user-attachments/assets/71363dcc-df48-4095-a982-5ead1ccf100f)
