### PR TITLE
feat(card): 약관 동의 페이지 UI 구현 완료

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,8 @@ import RefrigeratorMain from "./pages/refrigerator/RefrigeratorMain";
 import CardIssuePage from "./pages/card/CardIssuePage"; // 카드 발급 안내 페이지
 import CardDetailPage from "./pages/card/CardDetailPage"; // 카드 상세 페이지
 import CardDesignSelectionPage from "./pages/card/CardDesignSelectionPage"; // 카드 디자인 선택 페이지
-import CardIdentityVerificationPage from "./pages/card/CardIdentityVerificationPage"; // 본인 인증 페이지 추가
+import CardIdentityVerificationPage from "./pages/card/CardIdentityVerificationPage"; // 본인 인증 페이지
+import CardTermsPage from "./pages/card/CardTermsPage"; // 약관 동의 페이지
 
 function App() {
   return (
@@ -36,11 +37,15 @@ function App() {
         {/* 카드 신청 관련 라우트 */}
         <Route path="/card" element={<CardIssuePage />} />
         <Route path="/card/detail" element={<CardDetailPage />} />
-        <Route path="/card/design" element={<CardDesignSelectionPage />} />
         <Route
-          path="/card/identity-verification"
+          path="/card/apply/design"
+          element={<CardDesignSelectionPage />}
+        />
+        <Route
+          path="/card/apply/identity-verification"
           element={<CardIdentityVerificationPage />}
         />
+        <Route path="/card/apply/terms" element={<CardTermsPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/card/CardDesignSelection.css
+++ b/src/components/card/CardDesignSelection.css
@@ -112,7 +112,7 @@
   transform: translateY(-50%) scale(1.05);
 }
 
-/* 디자인 선택 영역 */
+/* 버튼(앞면, 뒷면, 꾸미러 가기) 영역 */
 .design-selection {
   width: 100%;
   display: flex;

--- a/src/components/card/CardDesignSelection.js
+++ b/src/components/card/CardDesignSelection.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import "./CardDesign.css";
+import "./CardDesignSelection.css";
 
 // 카드 디자인 타입 상수
 const CARD_VIEWS = {

--- a/src/components/card/CardDetail.css
+++ b/src/components/card/CardDetail.css
@@ -8,6 +8,13 @@
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   position: relative;
+  overflow: hidden;
+}
+
+.card-detail-content {
+  flex: 1; /* 남은 공간을 모두 차지 */
+  overflow-y: auto; /* 세로 스크롤 허용 */
+  padding: 0 20px;
 }
 
 /* 카드 이미지 및 시각적 정보 스타일 */
@@ -174,4 +181,23 @@ p {
 
 .dropdown-content p {
   margin-bottom: 10px;
+}
+
+.apply-button {
+  background-color: #7b68ee;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 50px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  width: 85%;
+  margin: 0 auto;
+  margin-bottom: 150px;
+}
+
+.apply-button:hover {
+  background-color: #5b4bc4;
 }

--- a/src/components/card/CardDetail.css
+++ b/src/components/card/CardDetail.css
@@ -17,7 +17,7 @@
   padding: 0 20px;
 }
 
-/* 카드 이미지 및 시각적 정보 스타일 */
+/* 카드 이미지 스타일 */
 .card-visual-section {
   margin-top: 12px;
   padding: 0px 16px;
@@ -141,8 +141,8 @@ p {
   line-height: 100%;
 }
 
-/* 카드 발급 유의사항 드롭다운 */
-.card-info-dropdown {
+/* 카드 발급 유의사항 드롭다운 섹션 */
+.card-info-dropdown-section {
   padding: 16px;
 }
 
@@ -183,6 +183,7 @@ p {
   margin-bottom: 10px;
 }
 
+/* 카드 신청 버튼 */
 .apply-button {
   background-color: #7b68ee;
   color: white;

--- a/src/components/card/CardDetail.js
+++ b/src/components/card/CardDetail.js
@@ -17,7 +17,7 @@ const CardDetail = ({ cardData, onNext }) => {
   return (
     <div className="card-detail-container">
       <div className="card-detail-content">
-        {/* 카드 이미지 및 정보 */}
+        {/* 카드 이미지 */}
         <div className="card-visual-section">
           <div className="card-image-container">
             <div className="card-image">
@@ -144,7 +144,7 @@ const CardDetail = ({ cardData, onNext }) => {
         </div>
 
         {/* 카드발급 유의사항 드롭다운 */}
-        <div className="card-info-dropdown">
+        <div className="card-info-dropdown-section">
           <div className="dropdown-header" onClick={toggleDropdown}>
             <span>카드발급 유의사항</span>
             <img

--- a/src/components/card/CardDetail.js
+++ b/src/components/card/CardDetail.js
@@ -3,7 +3,7 @@ import "./CardDetail.css";
 
 import detailArrow from "../../assets/detailArrow.svg";
 
-const CardDetail = ({ cardData }) => {
+const CardDetail = ({ cardData, onNext }) => {
   const { cardName, cardSubName, benefits } = cardData;
 
   // 드롭다운 열림/닫힘 상태 관리
@@ -16,147 +16,157 @@ const CardDetail = ({ cardData }) => {
 
   return (
     <div className="card-detail-container">
-      {/* 카드 이미지 및 정보 */}
-      <div className="card-visual-section">
-        <div className="card-image-container">
-          <div className="card-image">
-            <svg
-              width="100"
-              height="100"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            ></svg>
-          </div>
-        </div>
-
-        {/* 카드 이름 섹션 */}
-        <div className="card-title-section">
-          <h2>{cardName}</h2>
-          <h2>{cardSubName}</h2>
-          <div className="divider"></div>
-        </div>
-      </div>
-
-      {/* 혜택 정보 섹션 */}
-      <div className="card-benefits-section">
-        {benefits.map((benefit, index) => (
-          <div key={index} className="benefit-item">
-            <p>
-              <a className="benefit1 benefit-category">
-                {benefit.benefitTitle1}
-              </a>
-              <a className="benefit1 benefit-detail">
-                {benefit.benefitDetail1}
-              </a>
-            </p>
-            <p>
-              <a className="benefit2 benefit-category">
-                {benefit.benefitTitle2}
-              </a>
-              <a className="benefit2 benefit-detail">
-                {benefit.benefitDetail2}
-              </a>
-            </p>
-            <p>
-              <a className="benefit3 benefit-category">
-                {benefit.benefitTitle3}
-              </a>
-              <a className="benefit3 benefit-detail">
-                {benefit.benefitDetail3}
-              </a>
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* 연회비 섹션 */}
-      <div className="annual-fee-section">
-        <div className="view-more-button">
-          <span>연회비</span>
-          <img src={detailArrow} alt="View Details" className="detail-arrow" />
-        </div>
-        <div className="brand-section">
-          <div className="brand-label">
-            <span class="ico_brand">
+      <div className="card-detail-content">
+        {/* 카드 이미지 및 정보 */}
+        <div className="card-visual-section">
+          <div className="card-image-container">
+            <div className="card-image">
               <svg
-                width="44"
-                height="23"
-                viewBox="0 0 84 58"
+                width="100"
+                height="100"
+                viewBox="0 0 24 24"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M37.2957 39.7782H31.7032L35.2011 19.4772H40.7933L37.2957 39.7782Z"
-                  fill="#15195A"
-                />
-                <path
-                  d="M57.5686 19.9735C56.4655 19.5627 54.7159 19.1092 52.5525 19.1092C47.0298 19.1092 43.1407 21.8734 43.1168 25.8255C43.0709 28.7413 45.9013 30.3608 48.0182 31.333C50.1818 32.3265 50.9173 32.9749 50.9173 33.8605C50.8953 35.2205 49.169 35.8474 47.5588 35.8474C45.3261 35.8474 44.1297 35.5242 42.3116 34.7675L41.5752 34.4432L40.7926 39.0003C42.1043 39.5612 44.5208 40.0589 47.0298 40.0808C52.8978 40.0808 56.7181 37.3593 56.7633 33.1477C56.7857 30.8367 55.2911 29.066 52.069 27.619C50.113 26.6901 48.9151 26.0637 48.9151 25.1133C48.9381 24.2493 49.9283 23.3644 52.1363 23.3644C53.9544 23.321 55.2902 23.7312 56.3022 24.1417L56.808 24.3573L57.5686 19.9735Z"
-                  fill="#15195A"
-                />
-                <path
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"
-                  d="M67.5793 19.4772H71.9051L76.4168 39.7779H71.2387C71.2387 39.7779 70.732 37.4454 70.5714 36.7326H63.3911C63.1835 37.2723 62.2174 39.7779 62.2174 39.7779H56.3494L64.6563 21.1616C65.2319 19.844 66.2453 19.4772 67.5793 19.4772ZM67.2348 26.9062C67.2348 26.9062 65.4625 31.42 65.002 32.5863H69.6504C69.4204 31.5713 68.3614 26.7119 68.3614 26.7119L67.9706 24.9626C67.806 25.4131 67.568 26.0324 67.4074 26.4501C67.2986 26.7332 67.2254 26.9237 67.2348 26.9062Z"
-                  fill="#15195A"
-                />
-                <path
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"
-                  d="M7.47169 19.4772H16.4695C17.6891 19.5199 18.6787 19.8871 19.0007 21.1837L20.956 30.5102C20.9563 30.5111 20.9566 30.512 20.9568 30.5129L21.5553 33.3205L27.0322 19.4772H32.9458L24.1554 39.7567H18.2415L13.2569 22.1169C11.5371 21.1732 9.57422 20.4141 7.37964 19.8874L7.47169 19.4772Z"
-                  fill="#15195A"
-                />
-              </svg>
-            </span>
-            <span>1만5천원(일반)</span>
+              ></svg>
+            </div>
           </div>
-          <div className="brand-label">
-            <span class="ico_brand">
-              <svg
-                width="44"
-                height="23"
-                viewBox="0 0 84 58"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M49.6906 42.0159H34.6994V15.2427H49.6906V42.0159Z"
-                  fill="#FF5F00"
-                />
-                <path
-                  d="M35.6598 28.6272C35.6598 23.1961 38.2187 18.3583 42.2036 15.2406C39.2896 12.9607 35.6119 11.6 31.615 11.6C22.1529 11.6 14.4828 19.2232 14.4828 28.6272C14.4828 38.0311 22.1529 45.6543 31.615 45.6543C35.6119 45.6543 39.2896 44.2936 42.2036 42.0138C38.2187 38.8961 35.6598 34.0582 35.6598 28.6272Z"
-                  fill="#EB001B"
-                />
-                <path
-                  d="M69.9092 28.6272C69.9092 38.0311 62.239 45.6543 52.7769 45.6543C48.7801 45.6543 45.1024 44.2936 42.1873 42.0138C46.1732 38.8961 48.7321 34.0582 48.7321 28.6272C48.7321 23.1961 46.1732 18.3583 42.1873 15.2406C45.1024 12.9607 48.7801 11.6 52.7769 11.6C62.239 11.6 69.9092 19.2232 69.9092 28.6272Z"
-                  fill="#F79E1B"
-                />
-              </svg>
-            </span>
-            <span>1만5천원(일반)</span>
+
+          {/* 카드 이름 섹션 */}
+          <div className="card-title-section">
+            <h2>{cardName}</h2>
+            <h2>{cardSubName}</h2>
+            <div className="divider"></div>
           </div>
+        </div>
+
+        {/* 혜택 정보 섹션 */}
+        <div className="card-benefits-section">
+          {benefits.map((benefit, index) => (
+            <div key={index} className="benefit-item">
+              <p>
+                <a className="benefit1 benefit-category">
+                  {benefit.benefitTitle1}
+                </a>
+                <a className="benefit1 benefit-detail">
+                  {benefit.benefitDetail1}
+                </a>
+              </p>
+              <p>
+                <a className="benefit2 benefit-category">
+                  {benefit.benefitTitle2}
+                </a>
+                <a className="benefit2 benefit-detail">
+                  {benefit.benefitDetail2}
+                </a>
+              </p>
+              <p>
+                <a className="benefit3 benefit-category">
+                  {benefit.benefitTitle3}
+                </a>
+                <a className="benefit3 benefit-detail">
+                  {benefit.benefitDetail3}
+                </a>
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* 연회비 섹션 */}
+        <div className="annual-fee-section">
+          <div className="view-more-button">
+            <span>연회비</span>
+            <img
+              src={detailArrow}
+              alt="View Details"
+              className="detail-arrow"
+            />
+          </div>
+          <div className="brand-section">
+            <div className="brand-label">
+              <span class="ico_brand">
+                <svg
+                  width="44"
+                  height="23"
+                  viewBox="0 0 84 58"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M37.2957 39.7782H31.7032L35.2011 19.4772H40.7933L37.2957 39.7782Z"
+                    fill="#15195A"
+                  />
+                  <path
+                    d="M57.5686 19.9735C56.4655 19.5627 54.7159 19.1092 52.5525 19.1092C47.0298 19.1092 43.1407 21.8734 43.1168 25.8255C43.0709 28.7413 45.9013 30.3608 48.0182 31.333C50.1818 32.3265 50.9173 32.9749 50.9173 33.8605C50.8953 35.2205 49.169 35.8474 47.5588 35.8474C45.3261 35.8474 44.1297 35.5242 42.3116 34.7675L41.5752 34.4432L40.7926 39.0003C42.1043 39.5612 44.5208 40.0589 47.0298 40.0808C52.8978 40.0808 56.7181 37.3593 56.7633 33.1477C56.7857 30.8367 55.2911 29.066 52.069 27.619C50.113 26.6901 48.9151 26.0637 48.9151 25.1133C48.9381 24.2493 49.9283 23.3644 52.1363 23.3644C53.9544 23.321 55.2902 23.7312 56.3022 24.1417L56.808 24.3573L57.5686 19.9735Z"
+                    fill="#15195A"
+                  />
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M67.5793 19.4772H71.9051L76.4168 39.7779H71.2387C71.2387 39.7779 70.732 37.4454 70.5714 36.7326H63.3911C63.1835 37.2723 62.2174 39.7779 62.2174 39.7779H56.3494L64.6563 21.1616C65.2319 19.844 66.2453 19.4772 67.5793 19.4772ZM67.2348 26.9062C67.2348 26.9062 65.4625 31.42 65.002 32.5863H69.6504C69.4204 31.5713 68.3614 26.7119 68.3614 26.7119L67.9706 24.9626C67.806 25.4131 67.568 26.0324 67.4074 26.4501C67.2986 26.7332 67.2254 26.9237 67.2348 26.9062Z"
+                    fill="#15195A"
+                  />
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M7.47169 19.4772H16.4695C17.6891 19.5199 18.6787 19.8871 19.0007 21.1837L20.956 30.5102C20.9563 30.5111 20.9566 30.512 20.9568 30.5129L21.5553 33.3205L27.0322 19.4772H32.9458L24.1554 39.7567H18.2415L13.2569 22.1169C11.5371 21.1732 9.57422 20.4141 7.37964 19.8874L7.47169 19.4772Z"
+                    fill="#15195A"
+                  />
+                </svg>
+              </span>
+              <span>1만5천원(일반)</span>
+            </div>
+            <div className="brand-label">
+              <span class="ico_brand">
+                <svg
+                  width="44"
+                  height="23"
+                  viewBox="0 0 84 58"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M49.6906 42.0159H34.6994V15.2427H49.6906V42.0159Z"
+                    fill="#FF5F00"
+                  />
+                  <path
+                    d="M35.6598 28.6272C35.6598 23.1961 38.2187 18.3583 42.2036 15.2406C39.2896 12.9607 35.6119 11.6 31.615 11.6C22.1529 11.6 14.4828 19.2232 14.4828 28.6272C14.4828 38.0311 22.1529 45.6543 31.615 45.6543C35.6119 45.6543 39.2896 44.2936 42.2036 42.0138C38.2187 38.8961 35.6598 34.0582 35.6598 28.6272Z"
+                    fill="#EB001B"
+                  />
+                  <path
+                    d="M69.9092 28.6272C69.9092 38.0311 62.239 45.6543 52.7769 45.6543C48.7801 45.6543 45.1024 44.2936 42.1873 42.0138C46.1732 38.8961 48.7321 34.0582 48.7321 28.6272C48.7321 23.1961 46.1732 18.3583 42.1873 15.2406C45.1024 12.9607 48.7801 11.6 52.7769 11.6C62.239 11.6 69.9092 19.2232 69.9092 28.6272Z"
+                    fill="#F79E1B"
+                  />
+                </svg>
+              </span>
+              <span>1만5천원(일반)</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 카드발급 유의사항 드롭다운 */}
+        <div className="card-info-dropdown">
+          <div className="dropdown-header" onClick={toggleDropdown}>
+            <span>카드발급 유의사항</span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className={`dropdown-arrow ${isDropdownOpen ? "open" : ""}`}
+            />
+          </div>
+          {isDropdownOpen && (
+            <div className="dropdown-content">
+              <p>
+                카드 이용 시 제공되는 포인트 및 할인 혜택 등의 부가서비스는 카드
+                신규출시(2024.04.02) 이후 3년 이상 축소·폐지 없이 유지됩니다.
+              </p>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* 카드발급 유의사항 드롭다운 */}
-      <div className="card-info-dropdown">
-        <div className="dropdown-header" onClick={toggleDropdown}>
-          <span>카드발급 유의사항</span>
-          <img
-            src={detailArrow}
-            alt="Arrow"
-            className={`dropdown-arrow ${isDropdownOpen ? "open" : ""}`}
-          />
-        </div>
-        {isDropdownOpen && (
-          <div className="dropdown-content">
-            <p>
-              카드 이용 시 제공되는 포인트 및 할인 혜택 등의 부가서비스는 카드
-              신규출시(2024.04.02) 이후 3년 이상 축소·폐지 없이 유지됩니다.
-            </p>
-          </div>
-        )}
-      </div>
+      <button className="apply-button" onClick={onNext}>
+        카드 신청
+      </button>
     </div>
   );
 };

--- a/src/components/card/CardIdentityVerification.css
+++ b/src/components/card/CardIdentityVerification.css
@@ -65,6 +65,7 @@
 
 .separator {
   margin: 0 8px;
+  margin-bottom: 8px;
   font-size: 20px;
   color: #666;
 }

--- a/src/components/card/CardIdentityVerification.css
+++ b/src/components/card/CardIdentityVerification.css
@@ -22,7 +22,6 @@
   font-size: 22px;
   font-weight: bold;
   color: #333;
-  /* margin: 0 0 32px 0; */
 }
 
 .input-section {

--- a/src/components/card/CardIdentityVerification.js
+++ b/src/components/card/CardIdentityVerification.js
@@ -54,7 +54,7 @@ const CardIdentityVerificationPage = ({ onComplete }) => {
     if (isFormComplete && agreeToTerms) {
       // 실제로는 여기서 인증 번호를 검증하는 API 호출
       console.log("인증 완료 처리:", formData);
-      navigate("/card/terms"); // 다음 단계(약관 동의)로 이동
+      navigate("/card/apply/terms"); // 다음 단계(약관 동의)로 이동
     } else {
       // 실제 구현에서는 더 구체적인 피드백 제공
       alert("모든 정보를 입력하고 약관에 동의해주세요.");

--- a/src/components/card/CardTerms.css
+++ b/src/components/card/CardTerms.css
@@ -1,0 +1,184 @@
+.card-terms-container {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  position: relative;
+}
+
+.card-terms-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 32px;
+}
+
+.page-title {
+  padding-bottom: 32px;
+  text-align: left;
+}
+
+.page-title h2 {
+  font-size: 20px;
+  font-weight: bold;
+  color: #333;
+}
+
+.agreement-section {
+  border-bottom: 1px solid #cccccc;
+}
+
+.agreement-section.all-agreement {
+  border: 1px solid #cccccc;
+  border-radius: 12px;
+}
+
+.agreement-section.last {
+  border: none;
+  padding-bottom: 24px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 8px;
+  position: relative;
+  cursor: pointer;
+}
+
+.agreement-text {
+  font-size: 14px;
+  margin-left: 10px;
+  flex: 1;
+}
+
+/* 체크박스 커스텀 스타일 */
+input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #ddd;
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+input[type="checkbox"]:checked {
+  background-color: #7b68ee;
+  border-color: #7b68ee;
+}
+
+input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  width: 5px;
+  height: 10px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  left: 4.5px;
+  top: 1px;
+}
+
+/* 다음 버튼 스타일 */
+.terms.next-button {
+  width: 100%;
+  background-color: #7b68ee;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 50px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  margin: 0 auto;
+  margin-top: auto;
+  margin-bottom: 150px;
+}
+
+.terms.next-button:disabled {
+  background-color: #e0e0e0;
+  cursor: not-allowed;
+}
+
+.terms.next-button.active {
+  background-color: #7b68ee;
+  cursor: pointer;
+}
+
+/* 서브 약관 스타일 */
+.sub-agreement {
+  display: flex;
+  align-items: center;
+  margin: 12px 0;
+}
+
+.info-note {
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: #666;
+}
+
+/* 태그 스타일 */
+.label-tag {
+  background-color: #4caf50;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  margin-left: 8px;
+}
+
+.label-tag.blue {
+  background-color: #2196f3;
+}
+
+/* 마케팅 설명 부분 */
+.marketing-info {
+  padding: 10px 10px 10px 30px;
+  background-color: #f9f9f9;
+  margin-bottom: 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  color: #666;
+}
+
+.marketing-age-selection p {
+  font-size: 13px;
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.age-selection-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.age-button {
+  padding: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: white;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.age-button.selected {
+  border-color: #7b68ee;
+  color: #7b68ee;
+  font-weight: bold;
+}
+
+.disclaimer {
+  font-size: 11px !important;
+  color: #888 !important;
+  line-height: 1.4;
+  margin-top: 15px;
+}

--- a/src/components/card/CardTerms.js
+++ b/src/components/card/CardTerms.js
@@ -1,0 +1,245 @@
+import React, { useState } from "react";
+import "./CardTerms.css";
+import detailArrow from "../../assets/detailArrow.svg";
+
+const CardTerms = ({ onNext }) => {
+  // 약관 동의 상태 관리
+  const [allAgreed, setAllAgreed] = useState(false);
+  const [agreements, setAgreements] = useState({
+    allTerms: false,
+    personalInfo: false,
+    termsOfService: false,
+    financialInfo: false,
+    membershipBenefits: false,
+    personalInfoOptional: false,
+    cardUsageService: false,
+    cardIssuancePersonalInfo: false,
+    creditCardUsagePersonalInfo: false,
+  });
+
+  // 모든 약관 동의 토글
+  const handleAllAgreement = () => {
+    const newValue = !agreements.allTerms;
+
+    setAgreements({
+      ...agreements,
+      allTerms: newValue,
+      personalInfo: newValue,
+      termsOfService: newValue,
+      financialInfo: newValue,
+      membershipBenefits: newValue,
+      personalInfoOptional: newValue,
+      cardUsageService: newValue,
+      cardIssuancePersonalInfo: newValue,
+      creditCardUsagePersonalInfo: newValue,
+    });
+
+    setAllAgreed(newValue);
+  };
+
+  // 개별 약관 동의 토글
+  const handleAgreementChange = (key) => {
+    const newAgreements = {
+      ...agreements,
+      [key]: !agreements[key],
+    };
+
+    setAgreements(newAgreements);
+
+    const requiredAgreements = [
+      "personalInfo",
+      "termsOfService",
+      "financialInfo",
+      "membershipBenefits",
+    ];
+    const allRequiredChecked = requiredAgreements.every(
+      (k) => newAgreements[k]
+    );
+
+    // 모든 약관이 동의되었는지 확인
+    const allChecked = Object.keys(newAgreements)
+      .filter((k) => k !== "allTerms")
+      .every((k) => newAgreements[k]);
+
+    setAgreements({
+      ...newAgreements,
+      allTerms: allChecked,
+    });
+
+    // 필수 약관만 모두 체크되어도 다음 버튼 활성화
+    setAllAgreed(allRequiredChecked);
+  };
+
+  return (
+    <div className="card-terms-container">
+      <div className="card-terms-content">
+        <div className="page-title">
+          <h2>카드를 만들려면 약관 동의가 필요해요</h2>
+        </div>
+
+        {/* 모두 동의 */}
+        <div className="agreement-section all-agreement">
+          <label className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.allTerms}
+              onChange={handleAllAgreement}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">모두 동의</span>
+          </label>
+        </div>
+
+        {/* 개인(신용)정보 필수적 동의 섹션 */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.personalInfo}
+              onChange={() => handleAgreementChange("personalInfo")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              개인(신용)정보 필수적 동의(필수)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 약관 동의 섹션 */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.termsOfService}
+              onChange={() => handleAgreementChange("termsOfService")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              약관 동의 관한 필수적 동의(필수)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 발급심사 관련 동의 */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.financialInfo}
+              onChange={() => handleAgreementChange("financialInfo")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              발급심사 관련 동의에 관한 동의(필수)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 회원 가입 및 발급 신청에 관한 필수적 동의 */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.membershipBenefits}
+              onChange={() => handleAgreementChange("membershipBenefits")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              회원가입 및 발급신청에 관한 필수적 동의(필수)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 개인(신용)정보 동의(선택) 섹션 */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.personalInfoOptional}
+              onChange={() => handleAgreementChange("personalInfoOptional")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">개인(신용)정보 동의(선택)</span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 카드발급 관련 개인(신용)정보 동의(선택) */}
+        <div className="agreement-section">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.cardIssuancePersonalInfo}
+              onChange={() => handleAgreementChange("cardIssuancePersonalInfo")}
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              카드발급 관련 개인(신용)정보 동의(선택)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        {/* 신용평가기관 정보활용 */}
+        <div className="agreement-section last">
+          <div className="section-header">
+            <input
+              type="checkbox"
+              checked={agreements.creditCardUsagePersonalInfo}
+              onChange={() =>
+                handleAgreementChange("creditCardUsagePersonalInfo")
+              }
+            />
+            <span className="checkmark"></span>
+            <span className="agreement-text">
+              신용평가기관 정보활용 신성정보 저동인력(선택)
+            </span>
+            <img
+              src={detailArrow}
+              alt="Arrow"
+              className="terms dropdown-arrow"
+            />
+          </div>
+        </div>
+
+        <button
+          className={`terms next-button ${allAgreed ? "active" : ""}`}
+          onClick={onNext}
+          disabled={!allAgreed}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CardTerms;

--- a/src/pages/card/CardDesignSelectionPage.css
+++ b/src/pages/card/CardDesignSelectionPage.css
@@ -1,13 +1,12 @@
-.card-design-selection-page {
+.card-design-selection-page-container {
   width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: #ffffff;
   position: relative;
 }
 
-.card-design-page-content {
+.card-design-selection-component-container {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/src/pages/card/CardDesignSelectionPage.js
+++ b/src/pages/card/CardDesignSelectionPage.js
@@ -19,8 +19,8 @@ const CardDesignSelectionPage = () => {
   // 네비게이션 핸들러
   const handleBack = () => navigate(-1);
   const handleClose = () => navigate("/card");
-  const handleNext = () => navigate("/card/identity-verification");
-  const handleGoToCustomize = () => navigate("/card/customize");
+  const handleNext = () => navigate("/card/apply/identity-verification");
+  const handleGoToCustomize = () => navigate("/card/apply/customize");
 
   return (
     <div className="card-design-selection-page">

--- a/src/pages/card/CardDesignSelectionPage.js
+++ b/src/pages/card/CardDesignSelectionPage.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import "./CardDesignSelectionPage.css";
 
 // 카드 디자인 컴포넌트
-import CardDesign from "../../components/card/CardDesign";
+import CardDesignSelection from "../../components/card/CardDesignSelection";
 
 // 필요한 아이콘 import
 import backArrow from "../../assets/backArrow.svg";
@@ -23,7 +23,7 @@ const CardDesignSelectionPage = () => {
   const handleGoToCustomize = () => navigate("/card/apply/customize");
 
   return (
-    <div className="card-design-selection-page">
+    <div className="card-design-selection-page-container">
       <Header
         leftIcon={backArrow}
         title="카드 신청"
@@ -32,8 +32,11 @@ const CardDesignSelectionPage = () => {
         onRightClick={handleClose}
       />
 
-      <div className="card-design-page-content">
-        <CardDesign onNext={handleNext} onCustomize={handleGoToCustomize} />
+      <div className="card-design-selection-component-container">
+        <CardDesignSelection
+          onNext={handleNext}
+          onCustomize={handleGoToCustomize}
+        />
       </div>
 
       <Menu />

--- a/src/pages/card/CardDetailPage.css
+++ b/src/pages/card/CardDetailPage.css
@@ -1,4 +1,4 @@
-.card-detail-page {
+.card-detail-page-container {
   width: 100%;
   height: 100%;
   background-color: #ffffff;

--- a/src/pages/card/CardDetailPage.js
+++ b/src/pages/card/CardDetailPage.js
@@ -38,7 +38,7 @@ const CardDetailPage = () => {
   };
 
   return (
-    <div className="card-detail-container">
+    <div className="card-detail-page-container">
       <Header
         leftIcon={backArrow}
         title="신한카드 쏠픽(SOL Pick)"
@@ -47,7 +47,7 @@ const CardDetailPage = () => {
         onRightClick={handleClose}
       />
 
-      <div className="card-detail-page">
+      <div className="card-detail-component-container">
         <CardDetail cardData={cardData} onNext={handleNext} />
       </div>
 

--- a/src/pages/card/CardDetailPage.js
+++ b/src/pages/card/CardDetailPage.js
@@ -19,7 +19,7 @@ const CardDetailPage = () => {
   // 네비게이션 핸들러
   const handleGoBack = () => navigate(-1);
   const handleClose = () => navigate("/card");
-  const handleNext = () => navigate("/card/design");
+  const handleNext = () => navigate("/card/apply/design");
 
   // 카드 상세 데이터 (실제 구현에서는 API로 가져올 수 있음)
   const cardData = {

--- a/src/pages/card/CardDetailPage.js
+++ b/src/pages/card/CardDetailPage.js
@@ -1,19 +1,25 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
+
 // 카드 성세 컴포넌트
 import CardDetail from "../../components/card/CardDetail";
 import "./CardDetailPage.css";
+
 // 헤더 및 푸터 관련 컴포넌트
-import MainHeader from "../../components/common/header/MainHeader";
-import noti from "../../assets/noti.svg";
-import notiActive from "../../assets/notiActive.svg";
-import shop from "../../assets/shop.svg";
-import shopActive from "../../assets/shopActive.svg";
+import Header from "../../components/common/header/Header";
 import Menu from "../../components/common/menu/Menu";
 
-const CardDetailPage = () => {
-  const navigateToShop = () => {};
+// 필요한 아이콘 import
+import backArrow from "../../assets/backArrow.svg";
+import close from "../../assets/close.svg";
 
-  const navigateToNoti = () => {};
+const CardDetailPage = () => {
+  const navigate = useNavigate();
+
+  // 네비게이션 핸들러
+  const handleGoBack = () => navigate(-1);
+  const handleClose = () => navigate("/card");
+  const handleNext = () => navigate("/card/design");
 
   // 카드 상세 데이터 (실제 구현에서는 API로 가져올 수 있음)
   const cardData = {
@@ -32,18 +38,17 @@ const CardDetailPage = () => {
   };
 
   return (
-    <div className="card-container">
-      <MainHeader
-        leftIcon={shop}
-        leftIconActive={shopActive}
-        rightIcon={noti}
-        rightIconActive={notiActive}
-        onLeftClick={navigateToShop}
-        onRightClick={navigateToNoti}
+    <div className="card-detail-container">
+      <Header
+        leftIcon={backArrow}
+        title="신한카드 쏠픽(SOL Pick)"
+        rightIcon={close}
+        onLeftClick={handleGoBack}
+        onRightClick={handleClose}
       />
 
       <div className="card-detail-page">
-        <CardDetail cardData={cardData} />
+        <CardDetail cardData={cardData} onNext={handleNext} />
       </div>
 
       <Menu />

--- a/src/pages/card/CardIdentityVerificationPage.js
+++ b/src/pages/card/CardIdentityVerificationPage.js
@@ -22,7 +22,7 @@ const CardIdentityVerificationPage = () => {
 
   // 인증 완료 핸들러
   const handleVerificationComplete = () => {
-    navigate("/card/terms"); // 다음 단계(약관 동의)로 이동
+    navigate("/card/apply/terms"); // 다음 단계(약관 동의)로 이동
   };
 
   return (

--- a/src/pages/card/CardIdentityVerificationPage.js
+++ b/src/pages/card/CardIdentityVerificationPage.js
@@ -20,11 +20,6 @@ const CardIdentityVerificationPage = () => {
   const handleGoBack = () => navigate(-1);
   const handleClose = () => navigate("/card");
 
-  // 인증 완료 핸들러
-  const handleVerificationComplete = () => {
-    navigate("/card/apply/terms"); // 다음 단계(약관 동의)로 이동
-  };
-
   return (
     <div className="identity-verification-page">
       <Header
@@ -36,7 +31,7 @@ const CardIdentityVerificationPage = () => {
       />
 
       <div className="identity-verification-page-content">
-        <CardIdentityVerification onComplete={handleVerificationComplete} />
+        <CardIdentityVerification />
       </div>
 
       <Menu />

--- a/src/pages/card/CardIssuePage.css
+++ b/src/pages/card/CardIssuePage.css
@@ -1,5 +1,5 @@
 /* 메인 컨테이너 스타일 */
-.card-container {
+.card-issue-page-container {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,7 +9,7 @@
 }
 
 /* 카드 컨테이너 스타일 */
-.card-wrapper {
+.card-detail-handler-container {
   margin-top: 24px;
   width: 300px;
   height: 180px;

--- a/src/pages/card/CardIssuePage.js
+++ b/src/pages/card/CardIssuePage.js
@@ -21,7 +21,7 @@ const CardIssuePage = () => {
   };
 
   const handleCardIssue = () => {
-    navigate("/card/design");
+    navigate("/card/apply/design");
   };
 
   return (

--- a/src/pages/card/CardIssuePage.js
+++ b/src/pages/card/CardIssuePage.js
@@ -25,7 +25,7 @@ const CardIssuePage = () => {
   };
 
   return (
-    <div className="card-container">
+    <div className="card-issue-page-container">
       <MainHeader
         leftIcon={shop}
         leftIconActive={shopActive}
@@ -34,7 +34,11 @@ const CardIssuePage = () => {
         onLeftClick={navigateToShop}
         onRightClick={navigateToNoti}
       />
-      <div className="card-wrapper" onClick={handleCardDetail}></div>
+
+      <div
+        className="card-detail-handler-container"
+        onClick={handleCardDetail}
+      ></div>
 
       <div className="message-container">
         <h2 className="message-title">

--- a/src/pages/card/CardTermsPage.css
+++ b/src/pages/card/CardTermsPage.css
@@ -1,0 +1,16 @@
+.card-terms-page-container {
+  width: 100%;
+  height: 100%;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+.card-terms-component-container {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/card/CardTermsPage.js
+++ b/src/pages/card/CardTermsPage.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+// 카드 성세 컴포넌트
+import CardTerms from "../../components/card/CardTerms";
+import "./CardTermsPage.css";
+
+// 헤더 및 푸터 관련 컴포넌트
+import Header from "../../components/common/header/Header";
+import Menu from "../../components/common/menu/Menu";
+
+// 필요한 아이콘 import
+import backArrow from "../../assets/backArrow.svg";
+import close from "../../assets/close.svg";
+
+const CardTermsPage = () => {
+  const navigate = useNavigate();
+
+  // 네비게이션 핸들러
+  const handleGoBack = () => navigate(-1);
+  const handleClose = () => navigate("/card");
+
+  return (
+    <div className="card-terms-page-container">
+      <Header
+        leftIcon={backArrow}
+        title="약관 동의"
+        rightIcon={close}
+        onLeftClick={handleGoBack}
+        onRightClick={handleClose}
+      />
+
+      <div className="card-terms-component-container">
+        <CardTerms />
+      </div>
+
+      <Menu />
+    </div>
+  );
+};
+
+export default CardTermsPage;


### PR DESCRIPTION
## #️⃣연관된 이슈
#13 

## 📝작업 내용
1. 코드 구조 및 클래스 명명 규칙 통일
```
// components/card/CardDesignSelection.js
```

`파일명 + container` → `className="card-design-selection-container"`

`파일명 + content` → `className="card-design-selection-content"`

```
// pages/card/CardDesignSelectionPage.js
```

`파일명(Page 포함) + container` → `className="card-design-selection-page-container"`

`파일명(Page 제외) + component + container` → `className="card-design-selection-component-container"`

2. 약관 동의 페이지 UI 구현
- 모두 동의 시 다음 버튼 활성화
- 필수 약관 동의 시 다음 버튼 활성화

#### 스크린샷

**1. 약관 동의**

![약관 동의](https://github.com/user-attachments/assets/2930ac15-3797-4a49-9470-3bcc158ded7e)

**2. 지금까지 전체 흐름**

![전체1](https://github.com/user-attachments/assets/f453401f-ede6-4322-b7cf-489f430690cc)
![전체2](https://github.com/user-attachments/assets/28968690-38e4-4d68-84dd-f248d3a8b9c7)




