### PR TITLE
feat(card): 카드 발급 완료 페이지 UI 구현 완료

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import CardIdentityVerificationPage from "./pages/card/CardIdentityVerificationP
 import CardTermsPage from "./pages/card/CardTermsPage"; // 약관 동의 페이지
 import CardCreditRatingPage from "./pages/card/CardCreditRatingPage"; // 신용 정보 확인 페이지
 import CardApplyInfoPage from "./pages/card/CardApplyInfoPage"; // 카드 신청 정보 입력 페이지
+import CardCompletionPage from "./pages/card/CardCompletionPage"; // 카드 발급 완료 페이지 추가
 
 function App() {
   return (
@@ -53,6 +54,7 @@ function App() {
           element={<CardCreditRatingPage />}
         />
         <Route path="/card/apply/apply-info" element={<CardApplyInfoPage />} />
+        <Route path="/card/apply/completion" element={<CardCompletionPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/card/CardCompletion.css
+++ b/src/components/card/CardCompletion.css
@@ -1,0 +1,105 @@
+.card-completion-container {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  position: relative;
+}
+
+.card-completion-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 32px;
+}
+
+.check-icon-container {
+  width: 80px;
+  height: 80px;
+  background-color: #f3f4fa;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 40px auto 24px;
+}
+
+.check-icon {
+  width: 40px;
+  height: 40px;
+  fill: #5a5eb9;
+  stroke: #5a5eb9;
+  stroke-width: 2;
+  animation: checkmark 0.8s ease-in-out forwards;
+}
+
+@keyframes checkmark {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.card-completion-title {
+  padding-bottom: 20px;
+}
+
+.card-completion-title h2 {
+  margin-top: 12px;
+  font-size: 22px;
+  font-weight: bold;
+  text-align: center;
+  color: #333;
+}
+
+/* 카드 프리뷰 영역 */
+.card-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 20px;
+  margin-bottom: 30px;
+}
+
+/* 카드 이미지 스타일 */
+.card-image {
+  width: 190px;
+  height: 300px;
+  border-radius: 16px;
+  position: relative;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s;
+  transform-style: preserve-3d;
+  perspective: 1000px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.completion.confirm-button {
+  background-color: #7b68ee;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 50px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  width: 100%;
+  margin: auto auto 120px;
+}
+
+.confirm-button:hover {
+  background-color: #5b4bc4;
+}

--- a/src/components/card/CardCompletion.css
+++ b/src/components/card/CardCompletion.css
@@ -23,7 +23,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 40px auto 24px;
+  margin: 24px auto 24px;
 }
 
 .check-icon {

--- a/src/components/card/CardCompletion.js
+++ b/src/components/card/CardCompletion.js
@@ -1,0 +1,35 @@
+import React from "react";
+import "./CardCompletion.css";
+
+const CardCompletion = ({ onConfirm }) => {
+  return (
+    <div className="card-completion-container">
+      <div className="card-completion-content">
+        {/* 체크 아이콘 */}
+        <div className="check-icon-container">
+          <svg className="check-icon" viewBox="0 0 24 24">
+            <path
+              d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+
+        <div className="card-completion-title">
+          <h2>신한카드 쏠픽(SOL Pick)</h2>
+          <h2>신청완료!</h2>
+        </div>
+
+        <div className="card-preview">
+          <div className="card-image"></div>
+        </div>
+
+        <button className="completion confirm-button" onClick={onConfirm}>
+          확인
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CardCompletion;

--- a/src/components/card/CardCreditRating.css
+++ b/src/components/card/CardCreditRating.css
@@ -172,7 +172,7 @@ input[type="checkbox"]:checked::after {
   line-height: 1.5;
 }
 
-.phone-number {
+.inquire-phone-number {
   display: flex;
   align-items: center;
   font-weight: 600;

--- a/src/components/card/CardCreditRating.js
+++ b/src/components/card/CardCreditRating.js
@@ -148,7 +148,7 @@ const CardCreditRating = ({ onNext }) => {
         {/* 안내 텍스트 */}
         <div className="help-text">
           <p>상품에 대해 더 궁금하시면, 아래 전화상담을 이용해 주세요.</p>
-          <p className="phone-number">
+          <p className="inquire-phone-number">
             <span className="phone-icon">📞</span>
             전화상담: 1544-7000
           </p>

--- a/src/pages/card/CardApplyInfoPage.js
+++ b/src/pages/card/CardApplyInfoPage.js
@@ -19,7 +19,7 @@ const CardApplyInfoPage = () => {
   // 네비게이션 핸들러
   const handleGoBack = () => navigate(-2);
   const handleClose = () => navigate("/card");
-  const handleNext = () => navigate("/card/apply/");
+  const handleNext = () => navigate("/card/apply/completion");
 
   return (
     <div className="card-apply-info-page-container">

--- a/src/pages/card/CardCompletionPage.css
+++ b/src/pages/card/CardCompletionPage.css
@@ -1,0 +1,16 @@
+.card-completion-page-container {
+  width: 100%;
+  height: 100%;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+.card-completion-component-container {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/card/CardCompletionPage.js
+++ b/src/pages/card/CardCompletionPage.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import "./CardCompletionPage.css";
+
+// 컴포넌트 불러오기
+import CardCompletion from "../../components/card/CardCompletion";
+
+// 헤더 및 푸터 관련 컴포넌트
+import Header from "../../components/common/header/Header";
+import Menu from "../../components/common/menu/Menu";
+
+const CardCompletionPage = () => {
+  const navigate = useNavigate();
+
+  // 네비게이션 핸들러
+  const handleConfirm = () => navigate("/main");
+
+  return (
+    <div className="card-completion-page-container">
+      <Header title="발급 완료" />
+
+      <div className="card-completion-component-container">
+        <CardCompletion onConfirm={handleConfirm} />
+      </div>
+
+      <Menu />
+    </div>
+  );
+};
+
+export default CardCompletionPage;


### PR DESCRIPTION
## #️⃣연관된 이슈
#13 

## 📝작업 내용
- 카드 발급 완료 페이지 UI 구현 완료

#### 스크린샷
![가드 발급 완료](https://github.com/user-attachments/assets/ea016c5c-ecc8-4bd3-a31e-05269d0c38fd)

## 🎯남은 일
- [ ] 카드 탭 클릭 시 첫 화면 
  - 이미 발급 받은 경우 -> 포인트 내역 페이지
  - 미발급 경우 -> 카드 발급 받기 페이지
- [ ] 카드 기본 디자인 이미지
- [ ] 카드 커스텀 디자인 이미지
- [ ] 카드 방향 선택 페이지
- [ ] 카드 배경 선택 페이지(배경 4종)
- [ ] 카드 스티커 선택 페이지(스티커 15개/30개)
- [ ] 본인 인증 페이지 / 회원 영문 성 및 영문 이름 DB에 저장 **(BE)**
- [ ] 디자인 완료된 최종 카드 이미지 DB에 저장 **(BE)**
- [ ] 카드 발급 완료 페이지 / 카드 정보 생성 **(BE)**
  - 영문 성, 영문 이름, 최종 카드 이미지 -> DB에서 불러오기
  - 모든 정보 DB에 저장
