### PR TITLE
design: 메인 헤더에 안 읽은 알림 갯수 뱃지 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -60,7 +60,7 @@ function App() {
         <Route path="/refrigerator/list" element={<IngredientDetailList />} />
         <Route path="/refrigerator/main-1" element={<RefrigeratorMain />} /> {/* 냉장고 메인 v1 */}
         <Route path="/refrigerator/main-2" element={<RefrigeratorMainv2 />} /> {/* 냉장고 메인 v2 */}
-        <Route path="/refrigerator/main" element={<RefrigeratorMainCarousel />} />
+        <Route path="/refrigerator" element={<RefrigeratorMainCarousel />} />
 
         {/* 레시피 */}
         <Route path="/recipe-loading" element={<RecipeLoading />} />

--- a/src/App.js
+++ b/src/App.js
@@ -56,21 +56,17 @@ function App() {
         <Route path="/noti" element={<Noti />} />
 
         {/* 냉장고 */}
-        <Route path="/ingredientaddform" element={<IngredientAddForm />} />
-        <Route
-          path="/ingredientdetaillist"
-          element={<IngredientDetailList />}
-        />
-        {/* 냉장고 메인 */}
-        <Route path="/refrigeratormain" element={<RefrigeratorMain />} />
-        <Route path="/refrigeratormain2" element={<RefrigeratorMainv2 />} />
-        <Route
-          path="/refrigeratormaincarousel"
-          element={<RefrigeratorMainCarousel />}
-        />
+        <Route path="/refrigerator/add" element={<IngredientAddForm />} />
+        <Route path="/refrigerator/list" element={<IngredientDetailList />} />
+        <Route path="/refrigerator/main-1" element={<RefrigeratorMain />} /> {/* 냉장고 메인 v1 */}
+        <Route path="/refrigerator/main-2" element={<RefrigeratorMainv2 />} /> {/* 냉장고 메인 v2 */}
+        <Route path="/refrigerator/main" element={<RefrigeratorMainCarousel />} />
+
+        {/* 레시피 */}
         <Route path="/recipe-loading" element={<RecipeLoading />} />
         <Route path="/recipe-recommendation" element={<RecipeRecommendation />} />
         <Route path="/recipe-detail/:id" element={<RecipeDetail />} />
+        
         {/* 카드 신청 관련 라우트 */}
         <Route path="/card" element={<CardIssuePage />} />
         <Route path="/card/detail" element={<CardDetailPage />} />

--- a/src/components/common/header/MainHeader.css
+++ b/src/components/common/header/MainHeader.css
@@ -26,3 +26,23 @@
   width: 24px;
   height: 24px;
 }
+
+.notification-icon-container {
+  position: relative;
+  display: inline-block;
+}
+
+.notification-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  background-color: #7b68ee;
+  color: #ffffff;
+  font-size: 10px;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/common/header/MainHeader.js
+++ b/src/components/common/header/MainHeader.js
@@ -8,6 +8,7 @@ const MainHeader = ({
   rightIconActive,
   onLeftClick,
   onRightClick,
+  unreadNotifications = 5,
 }) => {
   const [isLeftActive, setIsLeftActive] = useState(false);
   const [isRightActive, setIsRightActive] = useState(false);
@@ -41,14 +42,17 @@ const MainHeader = ({
             />
           )}
           {rightIcon && (
-            <img
-              className="mainHeader-icon"
-              src={
-                isRightActive && rightIconActive ? rightIconActive : rightIcon
-              }
-              alt="right icon"
-              onClick={handleRightClick}
-            />
+            <div className="notification-icon-container">
+              <img
+                className="mainHeader-icon"
+                src={
+                  isRightActive && rightIconActive ? rightIconActive : rightIcon
+                }
+                alt="right icon"
+                onClick={handleRightClick}
+              />
+              <span className="notification-badge bold">{unreadNotifications > 9 ? "9+" : unreadNotifications}</span>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/common/menu/Menu.js
+++ b/src/components/common/menu/Menu.js
@@ -35,7 +35,7 @@ const Menu = () => {
       icon: refrigerator,
       activeIcon: refrigeratorActive,
       label: "냉장고",
-      path: "/refrigeratormain",
+      path: "/refrigerator/main",
     },
     {
       id: "mypage",

--- a/src/components/common/menu/Menu.js
+++ b/src/components/common/menu/Menu.js
@@ -35,7 +35,7 @@ const Menu = () => {
       icon: refrigerator,
       activeIcon: refrigeratorActive,
       label: "냉장고",
-      path: "/refrigerator/main",
+      path: "/refrigerator",
     },
     {
       id: "mypage",

--- a/src/components/refrigerator/popup/AddPopup.js
+++ b/src/components/refrigerator/popup/AddPopup.js
@@ -24,7 +24,7 @@ const AddPopup = ({ isOpen, onClose }) => {
     };
 
     // 등록 페이지로 이동하면서 데이터 전달
-    navigate("/ingredientaddform", {
+    navigate("/refrigerator/add", {
       state: {
         fromReceipt: true,
         receiptData,
@@ -38,7 +38,7 @@ const AddPopup = ({ isOpen, onClose }) => {
 
   const handleManualInputClick = () => {
     // 직접 입력 페이지로 이동할 때 state 정보 같이 전달
-    navigate("/ingredientaddform", {
+    navigate("/refrigerator/add", {
       state: {
         fromReceipt: false, // 직접 입력 모드임을 명시
       },

--- a/src/pages/refrigerator/main/RefrigeratorMain.js
+++ b/src/pages/refrigerator/main/RefrigeratorMain.js
@@ -149,7 +149,7 @@ const RefrigeratorMain = () => {
   };
 
   const navigateToIngredientList = () => {
-    navigate("/ingredientdetaillist");
+    navigate("/refrigerator/list");
   };
 
   // 선반 위치 계산

--- a/src/pages/refrigerator/main/RefrigeratorMainCarousel.js
+++ b/src/pages/refrigerator/main/RefrigeratorMainCarousel.js
@@ -403,7 +403,7 @@ const RefrigeratorMain2WithCarousel = () => {
   };
 
   const navigateToIngredientList = () => {
-    navigate("/ingredientdetaillist");
+    navigate("/refrigerator/list");
   };
 
   // 총 식재료 수 계산

--- a/src/pages/refrigerator/main/RefrigeratorMainv2.js
+++ b/src/pages/refrigerator/main/RefrigeratorMainv2.js
@@ -6,7 +6,7 @@ import Menu from "../../../components/common/menu/Menu";
 import { useNavigate } from "react-router-dom";
 import Popup from "../../../components/common/popup/Popup";
 
-// 기존 RefrigeratorHeader 사용 - 실제 프로젝트에서는 고유 컴포넌트 생성 고려
+// 기존 RefrigeratorHeader 사용
 import RefrigeratorHeader from "../../../components/refrigerator/main/RefrigeratorHeader";
 import RefrigeratorCarousel from "../../../components/refrigerator/main/RefrigeratorCarousel";
 import IngredientDetailContent from "../../../components/refrigerator/popup/IngredientDetailContent";
@@ -139,7 +139,7 @@ const RefrigeratorMain2WithCarousel = () => {
   };
 
   const navigateToIngredientList = () => {
-    navigate("/ingredientdetaillist");
+    navigate("/refrigerator/list");
   };
 
   // 총 식재료 수 계산

--- a/src/pages/refrigerator/recommendation/RecipeRecommendation.js
+++ b/src/pages/refrigerator/recommendation/RecipeRecommendation.js
@@ -38,7 +38,7 @@ const RecipeRecommendation = () => {
       <Header
         leftIcon={backArrow}
         title="🍽️ 추천 레시피"
-        onLeftClick={() => navigate("/refrigerator/main")}
+        onLeftClick={() => navigate("/refrigerator")}
       />
       <div className="recipe-recommendation-container">
         <div className="recipe-grid">

--- a/src/pages/refrigerator/recommendation/RecipeRecommendation.js
+++ b/src/pages/refrigerator/recommendation/RecipeRecommendation.js
@@ -38,7 +38,7 @@ const RecipeRecommendation = () => {
       <Header
         leftIcon={backArrow}
         title="🍽️ 추천 레시피"
-        onLeftClick={() => navigate("/refrigeratormaincarousel")}
+        onLeftClick={() => navigate("/refrigerator/main")}
       />
       <div className="recipe-recommendation-container">
         <div className="recipe-grid">


### PR DESCRIPTION
## #️⃣연관된 이슈
> - #48 

## 📝작업 내용
> 1. 냉장고 관련 라우트 패스 수정 
> - 냉장고 메인 `/refrigerator`
> - 식재료 등록 페이지 `/refrigerator/add`
> - 식재료 목록 페이지 `/refrigerator/list`
> 2. 메인 헤더에 안 읽은 알림 갯수 뱃지 추가
>
> ![image](https://github.com/user-attachments/assets/28c2fb52-17a4-44f6-8ed0-35a7397a97f5)