### PR TITLE
feat: 알림 관련 API 연동 및 데이터 통신 구현

### DIFF
--- a/src/api/AuthApi.js
+++ b/src/api/AuthApi.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { BASE_URL } from '../config'; // src\config.js의 BASE_URL 설정 공유
 
-const BASE_URL = 'http://localhost:8090';
+// const BASE_URL = 'http://localhost:8090';
 
 export const authApi = {
     login: async (email, password) => {

--- a/src/api/NotificationApi.js
+++ b/src/api/NotificationApi.js
@@ -1,6 +1,6 @@
-import axios from 'axios';
-import { BASE_URL } from '../config';
-import { authApi } from './AuthApi';
+import axios from "axios";
+import { BASE_URL } from "../config";
+import { authApi } from "./AuthApi";
 
 export const notificationApi = {
   // 읽지 않은 알림 개수 가져오기
@@ -9,7 +9,7 @@ export const notificationApi = {
       const response = await axios.get(
         `${BASE_URL}/solpick/noti/count/unread/${memberId}`,
         {
-          headers: authApi.getAuthHeader()
+          headers: authApi.getAuthHeader(),
         }
       );
       return response.data;
@@ -25,30 +25,54 @@ export const notificationApi = {
       const response = await axios.get(
         `${BASE_URL}/solpick/noti/list/${memberId}`,
         {
-          headers: authApi.getAuthHeader()
+          headers: authApi.getAuthHeader(),
         }
       );
       return response.data;
     } catch (error) {
       console.error("읽지 않은 알림 개수 가져오기 실패:", error);
-      return []; 
+      return [];
     }
   },
 
   // 알림 읽음 처리
   markAsRead: async (notificationId) => {
     try {
-      await axios.patch(
+      console.log(`API 호출: 알림 ID ${notificationId} 읽음 처리 시작`);
+      const response = await axios.patch(
         `${BASE_URL}/solpick/noti/${notificationId}/read`,
         {},
         {
-          headers: authApi.getAuthHeader()
+          headers: authApi.getAuthHeader(),
         }
       );
-      return true;
+
+      console.log(
+        `API 응답: 알림 ID ${notificationId} 읽음 처리 결과`,
+        response
+      );
+
+      // 응답 상태 코드 확인
+      if (response.status >= 200 && response.status < 300) {
+        return true;
+      }
+      return false;
     } catch (error) {
-      console.error("알림 읽음 처리 실패:", error);
+      console.error(`알림 ID ${notificationId} 읽음 처리 실패:`, error);
+
+      //   // 오류 세부 정보 로깅
+      //   if (error.response) {
+      //     // 서버 응답이 있는 경우
+      //     console.error("서버 응답:", error.response.status, error.response.data);
+      //   } else if (error.request) {
+      //     // 요청은 보냈지만 응답이 없는 경우
+      //     console.error("응답 없음:", error.request);
+      //   } else {
+      //     // 요청 생성 중 문제 발생
+      //     console.error("요청 오류:", error.message);
+      //   }
+
       return false;
     }
-  }
+  },
 };

--- a/src/api/NotificationApi.js
+++ b/src/api/NotificationApi.js
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import { authApi } from './AuthApi';
+
+export const notificationApi = {
+  // 읽지 않은 알림 개수 가져오기
+  getUnreadCount: async (userId) => {
+    try {
+      const response = await axios.get(
+        `${BASE_URL}/solpick/noti/count/unread/${userId}`,
+        {
+          headers: authApi.getAuthHeader()
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("읽지 않은 알림 개수 가져오기 실패:", error);
+      return 0; // 에러 발생 시 0으로 표시
+    }
+  },
+
+  // 알림 목록 가져오기
+  getNotifications: async (userId) => {
+    try {
+      const response = await axios.get(
+        `${BASE_URL}/solpick/noti/list/${userId}`,
+        {
+          headers: authApi.getAuthHeader()
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("읽지 않은 알림 개수 가져오기 실패:", error);
+      return []; 
+    }
+  },
+
+  // 알림 읽음 처리
+  markAsRead: async (notificationId) => {
+    try {
+      await axios.patch(
+        `${BASE_URL}/solpick/noti/${notificationId}/read`,
+        {},
+        {
+          headers: authApi.getAuthHeader()
+        }
+      );
+      return true;
+    } catch (error) {
+      console.error("알림 읽음 처리 실패:", error);
+      return false;
+    }
+  }
+};

--- a/src/api/NotificationApi.js
+++ b/src/api/NotificationApi.js
@@ -4,10 +4,10 @@ import { authApi } from './AuthApi';
 
 export const notificationApi = {
   // 읽지 않은 알림 개수 가져오기
-  getUnreadCount: async (userId) => {
+  getUnreadCount: async (memberId) => {
     try {
       const response = await axios.get(
-        `${BASE_URL}/solpick/noti/count/unread/${userId}`,
+        `${BASE_URL}/solpick/noti/count/unread/${memberId}`,
         {
           headers: authApi.getAuthHeader()
         }
@@ -15,15 +15,15 @@ export const notificationApi = {
       return response.data;
     } catch (error) {
       console.error("읽지 않은 알림 개수 가져오기 실패:", error);
-      return 0; // 에러 발생 시 0으로 표시
+      return "?"; // 에러 발생 시 ?으로 표시
     }
   },
 
   // 알림 목록 가져오기
-  getNotifications: async (userId) => {
+  getNotifications: async (memberId) => {
     try {
       const response = await axios.get(
-        `${BASE_URL}/solpick/noti/list/${userId}`,
+        `${BASE_URL}/solpick/noti/list/${memberId}`,
         {
           headers: authApi.getAuthHeader()
         }

--- a/src/components/common/header/MainHeader.js
+++ b/src/components/common/header/MainHeader.js
@@ -30,9 +30,9 @@ const MainHeader = ({
         const isLoggedIn = authApi.isAuthenticated();
         const currentUser = authApi.getCurrentUser();
         
-        if (isLoggedIn && currentUser && currentUser.id) {
+        if (isLoggedIn && currentUser) {
           try {
-            const count = await notificationApi.getUnreadCount(currentUser.id);
+            const count = await notificationApi.getUnreadCount(currentUser.memberId);
             setUnreadNotifications(count);
           } catch (error) {
             console.error("읽지 않은 알림 개수 가져오기 실패:", error);

--- a/src/components/common/header/MainHeader.js
+++ b/src/components/common/header/MainHeader.js
@@ -1,59 +1,86 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./MainHeader.css";
+import shop from "../../../assets/shop.svg";
+import noti from "../../../assets/noti.svg";
+
+import { notificationApi } from "../../../api/NotificationApi";
+import { authApi } from "../../../api/AuthApi";
+import { useNavigate } from "react-router-dom";
 
 const MainHeader = ({
-  leftIcon,
-  rightIcon,
-  leftIconActive,
-  rightIconActive,
-  onLeftClick,
-  onRightClick,
-  unreadNotifications = 5,
+  // leftIcon,
+  // rightIcon,
+  // leftIconActive,
+  // rightIconActive,
+  // onLeftClick,
+  // onRightClick,
 }) => {
-  const [isLeftActive, setIsLeftActive] = useState(false);
-  const [isRightActive, setIsRightActive] = useState(false);
+  // const [isLeftActive, setIsLeftActive] = useState(false);
+  // const [isRightActive, setIsRightActive] = useState(false);
 
-  // 왼쪽 아이콘 클릭 핸들러
-  const handleLeftClick = () => {
-    setIsLeftActive(!isLeftActive);
-    if (onLeftClick) {
-      onLeftClick();
-    }
+  const navigate = useNavigate();
+
+  // 읽지 않은 알림 개수 상태 관리
+  const [unreadNotifications, setUnreadNotifications] = useState(0);
+
+    // 읽지 않은 알림 개수 가져오기
+    useEffect(() => {
+      const fetchUnreadNotifications = async () => {
+        // 사용자 로그인 여부 확인
+        const isLoggedIn = authApi.isAuthenticated();
+        const currentUser = authApi.getCurrentUser();
+        
+        if (isLoggedIn && currentUser && currentUser.id) {
+          try {
+            const count = await notificationApi.getUnreadCount(currentUser.id);
+            setUnreadNotifications(count);
+          } catch (error) {
+            console.error("읽지 않은 알림 개수 가져오기 실패:", error);
+          }
+        }
+      };
+  
+      fetchUnreadNotifications();
+      
+      // 주기적으로 알림 개수 업데이트
+      const interval = setInterval(fetchUnreadNotifications, 3600000); // 1시간마다 업데이트
+      
+      return () => clearInterval(interval);
+    }, []);
+
+  // 샵 아이콘 클릭 핸들러
+  const handleShopClick = () => {
+    // setIsLeftActive(!isLeftActive);
+    // 레시픽 쇼핑몰 이동
   };
 
-  // 오른쪽 아이콘 클릭 핸들러
-  const handleRightClick = () => {
-    setIsRightActive(!isRightActive);
-    if (onRightClick) {
-      onRightClick();
-    }
+  // 알림 아이콘 클릭 핸들러
+  const handleNotiClick = () => {
+    // setIsRightActive(!isRightActive);
+    navigate("/noti");
   };
 
   return (
     <header className="mainHeader-container">
       <div className="mainHeader">
         <div className="icon-container">
-          {leftIcon && (
             <img
               className="mainHeader-icon"
-              src={isLeftActive && leftIconActive ? leftIconActive : leftIcon}
-              alt="left icon"
-              onClick={handleLeftClick}
+              // src={isLeftActive && leftIconActive ? leftIconActive : leftIcon}
+              src={shop}
+              alt="shopIcon"
+              onClick={handleShopClick}
             />
-          )}
-          {rightIcon && (
             <div className="notification-icon-container">
               <img
                 className="mainHeader-icon"
-                src={
-                  isRightActive && rightIconActive ? rightIconActive : rightIcon
-                }
-                alt="right icon"
-                onClick={handleRightClick}
+                // src={isRightActive && rightIconActive ? rightIconActive : rightIcon}
+                src={noti}
+                alt="notiIcon"
+                onClick={handleNotiClick}
               />
               <span className="notification-badge bold">{unreadNotifications > 9 ? "9+" : unreadNotifications}</span>
             </div>
-          )}
         </div>
       </div>
     </header>

--- a/src/components/noti/noti-list/NotiItem.css
+++ b/src/components/noti/noti-list/NotiItem.css
@@ -1,7 +1,7 @@
 .noti-item {
   display: flex;
   flex-direction: row;
-  padding: 12px 28px;
+  padding: 12px 24px;
   align-items: center;
 }
 
@@ -14,26 +14,35 @@
   margin-left: 20px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   width: auto;
 }
 
 .noti-type {
   color: #7b68ee;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 100%;
   letter-spacing: -0.03em;
+  margin-bottom: 0;
 }
 
 .noti-detail {
-  font-size: 12px;
+  font-size: 14px;
   line-height: 160%;
   letter-spacing: -0.03em;
+  margin-bottom: 0;
 }
 
 .noti-item-time {
   color: #969696;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 100%;
   letter-spacing: -0.03em;
+  margin-bottom: 0;
+}
+
+.noti-item-unread {
+  background-color: #7b68ee0d;
+  /* border-left: 3px solid #ed3241; */
+  box-sizing: border-box;
 }

--- a/src/components/noti/noti-list/NotiItem.js
+++ b/src/components/noti/noti-list/NotiItem.js
@@ -1,5 +1,4 @@
 import "./NotiItem.css";
-
 import expirationIcon from "../../../assets/expiration.svg";
 import reorderIcon from "../../../assets/reorder.svg";
 
@@ -8,20 +7,12 @@ const iconMap = {
   reorder: reorderIcon,
 };
 
-const NotiItem = ({
-  type,
-  title,
-  description,
-  timestamp,
-  showDate = false,
-  date,
-}) => {
+const NotiItem = ({ type, title, description, timestamp, isRead = false }) => {
   const icon = iconMap[type];
 
   return (
     <>
-      {showDate && <div className="noti-date">{date}</div>}
-      <div className="noti-item">
+      <div className={`noti-item ${!isRead ? "noti-item-unread" : ""}`}>
         <img src={icon} alt={type} className="noti-icon" />
         <div className="noti-description">
           <p className="noti-type">{title}</p>

--- a/src/components/noti/noti-list/NotiList.css
+++ b/src/components/noti/noti-list/NotiList.css
@@ -4,12 +4,16 @@
   width: 100%;
 }
 
-.noti-group .noti-date {
+.noti-group {
+  margin-bottom: 16px;
+}
+
+.noti-date {
   color: #969696;
   font-size: 12px;
   line-height: 100%;
   letter-spacing: -0.03em;
-  padding: 12px 16px 0 16px;
+  padding: 12px 16px 4px 16px;
 }
 
 .noti-empty {
@@ -19,4 +23,17 @@
   height: calc(100vh - 102px);
   color: #969696;
   font-size: 14px;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 102px);
+  color: #969696;
+  font-size: 14px;
+}
+
+.noti-item-wrapper {
+  cursor: pointer;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,2 @@
+export const BASE_URL = 'http://localhost:8090'; // 개발 환경
+// export const BASE_URL = 'https://도메인.co.kr'; // 프로덕션 환경

--- a/src/pages/Components.js
+++ b/src/pages/Components.js
@@ -10,10 +10,10 @@ import Header from "../components/common/header/Header";
 import backArrow from "../assets/backArrow.svg";
 import close from "../assets/close.svg";
 import MainHeader from "../components/common/header/MainHeader";
-import noti from "../assets/noti.svg";
-import notiActive from "../assets/notiActive.svg";
-import shop from "../assets/shop.svg";
-import shopActive from "../assets/shopActive.svg";
+// import noti from "../assets/noti.svg";
+// import notiActive from "../assets/notiActive.svg";
+// import shop from "../assets/shop.svg";
+// import shopActive from "../assets/shopActive.svg";
 import Menu from "../components/common/menu/Menu";
 import ToastMessage from "../components/common/toastmessage/ToastMessage";
 import Chip from "../components/common/chip/Chip";
@@ -138,10 +138,10 @@ const Components = () => {
       <br />
 
       <MainHeader
-        leftIcon={shop}
-        leftIconActive={shopActive}
-        rightIcon={noti}
-        rightIconActive={notiActive}
+        // leftIcon={shop}
+        // leftIconActive={shopActive}
+        // rightIcon={noti}
+        // rightIconActive={notiActive}
         // onLeftClick={}
         // onRightClick={}
       />

--- a/src/pages/card/CardIssuePage.js
+++ b/src/pages/card/CardIssuePage.js
@@ -1,18 +1,18 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import MainHeader from "../../components/common/header/MainHeader";
-import noti from "../../assets/noti.svg";
-import notiActive from "../../assets/notiActive.svg";
-import shop from "../../assets/shop.svg";
-import shopActive from "../../assets/shopActive.svg";
+// import noti from "../../assets/noti.svg";
+// import notiActive from "../../assets/notiActive.svg";
+// import shop from "../../assets/shop.svg";
+// import shopActive from "../../assets/shopActive.svg";
 import Menu from "../../components/common/menu/Menu";
 import "./CardIssuePage.css";
 
 // 메인 컴포넌트
 const CardIssuePage = () => {
-  const navigateToShop = () => {};
+  // const navigateToShop = () => {};
 
-  const navigateToNoti = () => {};
+  // const navigateToNoti = () => {};
 
   const navigate = useNavigate();
 
@@ -27,12 +27,12 @@ const CardIssuePage = () => {
   return (
     <div className="card-issue-page-container">
       <MainHeader
-        leftIcon={shop}
-        leftIconActive={shopActive}
-        rightIcon={noti}
-        rightIconActive={notiActive}
-        onLeftClick={navigateToShop}
-        onRightClick={navigateToNoti}
+        // leftIcon={shop}
+        // leftIconActive={shopActive}
+        // rightIcon={noti}
+        // rightIconActive={notiActive}
+        // onLeftClick={navigateToShop}
+        // onRightClick={navigateToNoti}
       />
 
       <div

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -1,9 +1,9 @@
 import "./Main.css";
 import MainHeader from "../../components/common/header/MainHeader";
-import noti from "../../assets/noti.svg";
-import notiActive from "../../assets/notiActive.svg";
-import shop from "../../assets/shop.svg";
-import shopActive from "../../assets/shopActive.svg";
+// import noti from "../../assets/noti.svg";
+// import notiActive from "../../assets/notiActive.svg";
+// import shop from "../../assets/shop.svg";
+// import shopActive from "../../assets/shopActive.svg";
 import EventSection from "../../components/main/event-card/EventCard";
 import Menu from "../../components/common/menu/Menu";
 import { useNavigate } from "react-router-dom";
@@ -18,11 +18,11 @@ const Main = () => {
   const isLoggedIn = authApi.isAuthenticated();
   //
 
-  const navigateToShop = () => { };
+  // const navigateToShop = () => { };
 
-  const navigateToNoti = () => {
-    navigate("/noti");
-  };
+  // const navigateToNoti = () => {
+  //   navigate("/noti");
+  // };
 
   // 로그인 버튼 핸들러 추가
   const handleLoginClick = () => {
@@ -87,12 +87,12 @@ const Main = () => {
   return (
     <>
       <MainHeader
-        leftIcon={shop}
-        leftIconActive={shopActive}
-        rightIcon={noti}
-        rightIconActive={notiActive}
-        onLeftClick={navigateToShop}
-        onRightClick={navigateToNoti}
+        // leftIcon={shop}
+        // leftIconActive={shopActive}
+        // rightIcon={noti}
+        // rightIconActive={notiActive}
+        // onLeftClick={navigateToShop}
+        // onRightClick={navigateToNoti}
       />
 
       <p className="greeting-ment bold">

--- a/src/pages/mypage/MyPage.js
+++ b/src/pages/mypage/MyPage.js
@@ -1,31 +1,31 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 import MainHeader from "../../components/common/header/MainHeader";
 import Menu from "../../components/common/menu/Menu";
-import noti from "../../assets/noti.svg";
-import notiActive from "../../assets/notiActive.svg";
-import shop from "../../assets/shop.svg";
-import shopActive from "../../assets/shopActive.svg";
+// import noti from "../../assets/noti.svg";
+// import notiActive from "../../assets/notiActive.svg";
+// import shop from "../../assets/shop.svg";
+// import shopActive from "../../assets/shopActive.svg";
 import MyPageContent from "../../components/mypage/MyPageContent";
 
 const MyPage = () => {
-    const navigate = useNavigate();
+    // const navigate = useNavigate();
 
-    const navigateToShop = () => { };
+    // const navigateToShop = () => { };
 
-    const navigateToNoti = () => {
-        navigate("/noti");
-    };
+    // const navigateToNoti = () => {
+    //     navigate("/noti");
+    // };
 
     return (
         <>
             <MainHeader
-                leftIcon={shop}
-                leftIconActive={shopActive}
-                rightIcon={noti}
-                rightIconActive={notiActive}
-                onLeftClick={navigateToShop}
-                onRightClick={navigateToNoti}
+                // leftIcon={shop}
+                // leftIconActive={shopActive}
+                // rightIcon={noti}
+                // rightIconActive={notiActive}
+                // onLeftClick={navigateToShop}
+                // onRightClick={navigateToNoti}
             />
 
             <MyPageContent />

--- a/src/pages/noti/Noti.js
+++ b/src/pages/noti/Noti.js
@@ -5,8 +5,12 @@ import close from "../../assets/close.svg";
 import Chip from "../../components/common/chip/Chip";
 import { useEffect, useState } from "react";
 import NotiList from "../../components/noti/noti-list/NotiList";
+import { notificationApi } from "../../api/NotificationApi";
+import { authApi } from "../../api/AuthApi";
+import { useNavigate } from "react-router-dom";
 
 const Noti = () => {
+  const navigate = useNavigate();
   const chipItems = ["전체", "유통기한", "재구매"];
 
   const [notifications, setNotifications] = useState([]);
@@ -17,94 +21,68 @@ const Noti = () => {
     // API에서 알림 데이터를 가져오는 함수
     const fetchNotifications = async () => {
       try {
-        // 실제 환경에서는 API 호출로 대체
-        // const response = await fetch('/api/notifications');
-        // const data = await response.json();
+        setLoading(true);
 
-        // 예시 데이터
-        const mockData = [
-          {
-            id: "noti1",
-            type: "expiration",
-            title: "유통기한 알림",
-            description: "당근, 사과, 양배추의 유통기한이 얼마 남지 않았어요!",
-            timestamp: "2025. 03. 04. 09:00",
-          },
-          {
-            id: "noti2",
-            type: "expiration",
-            title: "유통기한 알림",
-            description: "우유의 유통기한이 1일 남았어요!",
-            timestamp: "2025. 03. 04. 09:00",
-          },
-          {
-            id: "noti3",
-            type: "reorder",
-            title: "재구매 알림",
-            description: "매주 월요일마다 사과를 구매했어요!",
-            timestamp: "2025. 03. 03. 11:45",
-          },
-          {
-            id: "noti4",
-            type: "reorder",
-            title: "재구매 알림",
-            description: "당근 살 때 안 되셨나요?",
-            timestamp: "2025. 03. 01. 08:20",
-          },
-          {
-            id: "noti5",
-            type: "expiration",
-            title: "유통기한 알림",
-            description: "우유의 유통기한이 1일 남았어요!",
-            timestamp: "2025. 02. 28. 09:00",
-          },
-          {
-            id: "noti6",
-            type: "expiration",
-            title: "유통기한 알림",
-            description: "체리의 유통기한이 3일 남았어요!",
-            timestamp: "2025. 02. 26. 09:00",
-          },
-          {
-            id: "noti7",
-            type: "expiration",
-            title: "유통기한 알림",
-            description: "우유의 유통기한이 1일 남았어요!",
-            timestamp: "2025. 02. 25. 09:00",
-          },
-          {
-            id: "noti8",
-            type: "reorder",
-            title: "재구매 알림",
-            description: "당근 살 때 안 되셨나요?",
-            timestamp: "2025. 03. 01. 08:00",
-          },
-          {
-            id: "noti9",
-            type: "reorder",
-            title: "재구매 알림",
-            description: "당근 살 때 안 되셨나요?",
-            timestamp: "2025. 03. 01. 13:00",
-          },
-          {
-            id: "noti10",
-            type: "reorder",
-            title: "재구매 알림",
-            description: "당근 살 때 안 되셨나요?",
-            timestamp: "2025. 03. 01. 12:00",
-          },
-        ];
+        // 사용자 정보 가져오기
+        const currentUser = authApi.getCurrentUser();
 
-        setNotifications(mockData);
+        if (currentUser && currentUser.memberId) {
+          const data = await notificationApi.getNotifications(
+            currentUser.memberId
+          );
+
+          // console.log("서버에서 받아온 알림 데이터:", data);
+
+          setNotifications(data);
+        } else {
+          // 로그인 안 된 경우 로그인 페이지로 이동
+          navigate("/login");
+        }
+
         setLoading(false);
       } catch (error) {
-        console.error("알림을 불러오는 중 오류가 발생했습니다:", error);
+        console.error("알림 불러오는 중 오류 발생:", error);
         setLoading(false);
       }
     };
 
     fetchNotifications();
   }, []);
+
+  // 알림 클릭 핸들러
+  const handleNotificationClick = async (notification) => {
+    // 알림이 읽지 않은 상태라면 읽음 처리
+    if (!notification.isRead) {
+      try {
+        console.log("알림 읽음 처리 시작:", notification.id);
+
+        // API 호출 전에 UI 업데이트는 하지 않음
+        const success = await notificationApi.markAsRead(notification.id);
+        console.log("알림 읽음 처리 결과:", success);
+
+        if (success) {
+          // API 호출이 성공한 후에만 UI 업데이트
+          console.log("알림 읽음 상태 UI 업데이트");
+          setNotifications((prev) =>
+            prev.map((item) =>
+              item.id === notification.id ? { ...item, isRead: true } : item
+            )
+          );
+        } else {
+          console.error(
+            "알림 읽음 처리 실패: 서버에서 성공 응답을 반환하지 않음"
+          );
+        }
+      } catch (error) {
+        console.error("알림 읽음 처리 오류:", error);
+      }
+    }
+    // 알림 타입에 따른 페이지 이동
+    if (notification.type === "expiration") {
+      navigate("/refrigerator");
+    }
+    // 다른 타입의 알림에 대한 처리 추가
+  };
 
   // 칩 필터링
   const filteredNotifications = notifications.filter((noti) => {
@@ -134,9 +112,12 @@ const Noti = () => {
       />
 
       {loading ? (
-        <div className="loading">로딩 페이지</div>
+        <div className="loading">알림을 불러오는 중...</div>
       ) : (
-        <NotiList notifications={filteredNotifications} />
+        <NotiList
+          notifications={filteredNotifications}
+          onNotificationClick={handleNotificationClick}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
> - #50 

## 📝작업 내용
> 1. `MainHeader` 동일한 아이콘, 동일한 내비게이션 링크만 쓰게 되는 것 같아서 아예 공통 컴포넌트 코드에 `shop`, `noti`로 고정 
> 2. 알림 관련 API 연동 및 데이터 통신 구현
> - `BASE_URL` 환경 변수 설정하는 `src\config` 파일 추가
> - 알림 관련 API 연동 위한 `api\NotificationApi.js` 작성 
> - 읽지 않은 알림 개수 가져와서 헤더 뱃지에 표시 
> - 알림 목록에서 읽지 않은 알림에 스타일 적용
> - 읽지 않은 알림 클릭 시 읽음 처리
> - 유통기한 알림 클릭 시 냉장고 페이지로 이동 
> ![noti_api](https://github.com/user-attachments/assets/deece0a7-637b-4561-956e-43430ad6432c)