### PR TITLE
feat(card): 카도 소유 여부 확인 API 연동 및 카드 방향 선택 관련 라우트 삭제

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ import RecipeDetail from "./pages/refrigerator/recommendation/RecipeDetail";
 import CardIssuePage from "./pages/card/CardIssuePage"; // 카드 발급 안내 페이지
 import CardDetailPage from "./pages/card/CardDetailPage"; // 카드 상세 페이지
 import CardDesignSelectionPage from "./pages/card/CardDesignSelectionPage"; // 카드 디자인 선택 페이지
-import CardCustomDirectionPage from "./pages/card/CardCustomDirectionPage"; // 카드 방향 선택 페이지
 import CardCustomBackgroundPage from "./pages/card/CardCustomBackgroundPage"; // 카드 배경 선택 페이지
 import CardCustomStickerPage from "./pages/card/CardCustomStickerPage"; // 카드 스티커 선택 페이지
 import CardIdentityVerificationPage from "./pages/card/CardIdentityVerificationPage"; // 본인 인증 페이지
@@ -78,10 +77,6 @@ function App() {
         <Route
           path="/card/apply/design"
           element={<CardDesignSelectionPage />}
-        />
-        <Route
-          path="/card/apply/custom/direction"
-          element={<CardCustomDirectionPage />}
         />
         <Route
           path="/card/apply/custom/background"

--- a/src/api/cardApi.js
+++ b/src/api/cardApi.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+const BASE_URL = "http://localhost:8090"; // 백엔드 서버 URL
+
+// 토큰 가져오기
+const getAuthHeader = () => {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+// 카드 소유 여부 확인
+export const checkHasCard = async () => {
+  try {
+    console.log("카드 소유 여부 확인 API 호출 중...");
+    const token = localStorage.getItem("token");
+    console.log("토큰 존재 여부:", !!token);
+
+    const response = await axios.get(`${BASE_URL}/api/card/has-card`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    console.log("카드 소유 여부 API 응답:", response.data);
+    return response.data.hasCard;
+  } catch (error) {
+    console.error("카드 소유 여부 확인 중 오류 발생:", error);
+    if (error.response) {
+      console.error("응답 데이터:", error.response.data);
+      console.error("응답 상태:", error.response.status);
+    }
+    return false;
+  }
+};

--- a/src/pages/card/CardIssuePage.js
+++ b/src/pages/card/CardIssuePage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import MainHeader from "../../components/common/header/MainHeader";
 import noti from "../../assets/noti.svg";
@@ -8,10 +8,48 @@ import shopActive from "../../assets/shopActive.svg";
 import Menu from "../../components/common/menu/Menu";
 import "./CardIssuePage.css";
 import BasicDesignFront from "../../assets/card/basicDesign.svg";
+import { checkHasCard } from "../../api/cardApi";
 
 // 메인 컴포넌트
 const CardIssuePage = () => {
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // 로그인 상태 확인
+    const token = localStorage.getItem("token");
+    console.log("토큰 존재 여부:", !!token);
+
+    if (!token) {
+      console.log("토큰이 없어 로그인 페이지로 이동합니다.");
+      navigate("/login");
+      return;
+    }
+
+    // 카드 소유 여부 확인
+    const checkCardStatus = async () => {
+      try {
+        console.log("카드 상태 확인 시작");
+        const hasCard = await checkHasCard();
+        console.log("카드 소유 여부:", hasCard);
+
+        if (hasCard) {
+          // 카드가 있으면 포인트 페이지로 이동
+          console.log("카드가 있어 포인트 페이지로 이동합니다.");
+          navigate("/point");
+        } else {
+          // 카드가 없으면 현재 페이지(카드 발급 페이지) 표시
+          console.log("카드가 없어 현재 페이지를 표시합니다.");
+          setLoading(false);
+        }
+      } catch (error) {
+        console.error("카드 상태 확인 중 오류 발생:", error);
+        setLoading(false);
+      }
+    };
+
+    checkCardStatus();
+  }, [navigate]);
 
   const navigateToShop = () => {};
   const navigateToNoti = () => {};
@@ -23,6 +61,10 @@ const CardIssuePage = () => {
   const handleCardIssue = () => {
     navigate("/card/detail");
   };
+
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <div className="card-issue-page-container">


### PR DESCRIPTION
## #️⃣연관된 이슈
#67 

## 📝작업 내용
- 카드 방향 선택 관련 라우트 삭제
- 카도 소유 여부 확인 API 연동

## 🔧테스트 방법
### 1. http://localhost:3000/login 접속
### 2. 카드 있는 경우
- test1@test.com/test1234 계정으로 로그인
- `카드` 택 클릭 -> http://localhost:3000/card 페이지로 이동될 것임
### 3. 카드가 없는 경우
- test7@test.com/test1234 계정으로 로그인
- `카드` 택 클릭 -> http://localhost:3000/point 페이지로 이동될 것임
